### PR TITLE
W-10811351: Update DW version to latest 2.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<revision>1.0.0</revision>
-		<data.weave.version>2.4.0-20211228</data.weave.version>
+		<data.weave.version>2.4.0-20220314</data.weave.version>
 		<data.weave.testing.framework.version>1.0.7-SNAPSHOT</data.weave.testing.framework.version>
 		<data.weave.maven.plugin.version>0.1.0</data.weave.maven.plugin.version>
 		<exchange.orgId>1e0dbdda-5cda-4968-a636-0980a2c42cb1</exchange.orgId>


### PR DESCRIPTION
Updated to 2.4.0-20220314 that is the one that generates the default pom of the DW extension